### PR TITLE
first draft of non reentrant implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ A small set of smart contracts.
 
 ## Contracts
 
-- `Ownable` : An ownable contract using the Two-Step Transfer Pattern
-- `Whitelisted` : Implementation of a whitelist as access control mechanism
+-   `Ownable` : An ownable contract using the Two-Step Transfer Pattern
+-   `Whitelisted` : Implementation of a whitelist as access control mechanism
+-   `PreventReentrant` : Gas efficient implementation for reentrancy protection
 
 ## Installation
 
@@ -20,6 +21,7 @@ forge install byterocket/solrocket
 ## Usage
 
 Common tasks are executed through a `Makefile`:
+
 ```
 make help
 > build         Build project
@@ -29,8 +31,6 @@ make help
 
 ## Safety
 
-This is experimental software and is provided on an "as is" and
-"as available" basis.
+This is experimental software and is provided on an "as is" and "as available" basis.
 
-We do not give any warranties and will not be liable for any loss incurred
-through any use of this codebase.
+We do not give any warranties and will not be liable for any loss incurred through any use of this codebase.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To install with [**Foundry**](https://github.com/gakonst/foundry):
 forge install byterocket/solrocket
 ```
 
-## Getting Started
+## Contributing
 
 Clone or fork `byterocket/solrocket`
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,26 @@ To install with [**Foundry**](https://github.com/gakonst/foundry):
 forge install byterocket/solrocket
 ```
 
+## Getting Started
+
+Clone or fork `byterocket/solrocket`
+
+```sh
+git clone https://github.com/byterocket/solrocket.git
+```
+
+Install dependencies
+
+```sh
+forge install
+```
+
+Test compilation
+
+```sh
+forge build
+```
+
 ## Usage
 
 Common tasks are executed through a `Makefile`:

--- a/src/PreventReentrant.sol
+++ b/src/PreventReentrant.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.10;
+
+/**
+* @dev A custom revert error is used in this implementation
+*      to save on gas associated with longer strings in require statements.
+*/
+error ReentrantCall();
+
+/**
+* @title PreventReentrant
+*/
+
+abstract contract PreventReentrant {
+
+    /**
+    * @dev Having both uint128 constants declared next to eachother 
+    *      allows them both fit into a single 256 bit slot. Unisgned integers
+    *      are used in this implementation to avoid the extra SLOAD required for the 
+    *      read, replace, and write operations of a boolean.
+    */
+
+    uint128 private constant NOT_ENTERED = 1;
+    uint128 private constant IS_ENTERED = 2;
+
+    uint256 private _status;
+
+    constructor() {
+        _status = NOT_ENTERED;
+    }
+
+    modifier nonReentrant {
+        /**
+        * @dev To prevent reentrancy, the modifier first checks that the status
+        *      is not entered and throws a custom revert error if the call is reentrant.
+        */
+        if (_status == IS_ENTERED) revert ReentrantCall();
+        // The modifier sets the status to entered for the duration of function execution.
+        _status = IS_ENTERED;
+        _;
+        // Restores the default value to not entered. 
+        _status = NOT_ENTERED;
+    }
+
+}
+


### PR DESCRIPTION
## PreventReentrant

This implementation is inspired by openzeppelin's reentrancy guard, with the main difference being error handling using Solidity 0.8's new custom revert feature. Locked and unlocked status is tracked using two unsigned integers of 128 bits declared next to each other to fit into one 256 bit slot. 

This is pushed to ***lab*** development branch.